### PR TITLE
adds custom get_user_id to coursera backend

### DIFF
--- a/social/backends/coursera.py
+++ b/social/backends/coursera.py
@@ -28,6 +28,10 @@ class CourseraOAuth2(BaseOAuth2):
         """Return user details from Coursera account"""
         return {'username': self._get_username_from_response(response)}
 
+    def get_user_id(self, details, response):
+        """Return a username prepared in get_user_details as uid"""
+        return details.get(self.ID_KEY)
+
     def user_data(self, access_token, *args, **kwargs):
         """Load user data from the service"""
         return self.get_json(


### PR DESCRIPTION
currently `coursera` backend is designed to use custom `username` key as `ID_KEY`
the `username` value is prepared and stored in `details` dict by `get_user_details`, however it doesn't override `get_user_id` method, which results in the app trying to fetch `username` from `response` dict.
